### PR TITLE
Use new GAIA Milky Way image

### DIFF
--- a/src/radiostars.vue
+++ b/src/radiostars.vue
@@ -379,7 +379,7 @@
 import { defineComponent, PropType, onMounted, ref } from 'vue';
 import { csvFormatRows, csvParse } from "d3-dsv";
 import { distance } from "@wwtelescope/astro";
-import { Color, Constellations, Folder, Layer, LayerManager, RenderContext, Settings, SpreadSheetLayer, WWTControl } from "@wwtelescope/engine"; //Grids, Poly
+import { Color, Constellations, Folder, Grids, Layer, LayerManager, RenderContext, Settings, SpreadSheetLayer, Texture, WWTControl } from "@wwtelescope/engine"; //Grids, Poly
 import { AltTypes, AltUnits, MarkerScales, PlotTypes, RAUnits, Thumbnail } from "@wwtelescope/engine-types"; //ImageSetType, PointScaleTypes
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import L, { Map } from "leaflet"; //LeafletMouseEvent
@@ -921,6 +921,8 @@ export default defineComponent({
       // @ts-ignore
       Constellations.initializeConstellationNames = initializeConstellationNames;
       //Grids._makeAltAzGridText = makeAltAzGridText;
+
+      Grids._milkyWayImage = Texture.fromUrl("https://www.cosmos.esa.int/documents/29201/20118332/MilkyWay_25J14_40KPC_Top_D53_5K_HighContrast_Smallest.jpg/26ecc3f3-f32f-6c53-1875-3c31d4a2b017?t=1736882726155");
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/radiostars.vue
+++ b/src/radiostars.vue
@@ -922,7 +922,7 @@ export default defineComponent({
       Constellations.initializeConstellationNames = initializeConstellationNames;
       //Grids._makeAltAzGridText = makeAltAzGridText;
 
-      Grids._milkyWayImage = Texture.fromUrl("https://www.cosmos.esa.int/documents/29201/20118332/MilkyWay_25J14_40KPC_Top_D53_5K_HighContrast_Smallest.jpg/26ecc3f3-f32f-6c53-1875-3c31d4a2b017?t=1736882726155");
+      Grids._milkyWayImage = Texture.fromUrl("https://data1.wwtassets.org/packages/2025/01_gaia_milky_way/Gaia-HighContrast-MilkyWay-sm.jpg");
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/shims-wwt.d.ts
+++ b/src/shims-wwt.d.ts
@@ -1,0 +1,18 @@
+import { Color, RenderContext } from "@wwtelescope/engine";
+
+declare module "@wwtelescope/engine" {
+  export class Grids {
+    static drawAltAzGrid(renderContext: RenderContext, opacity: number, drawColor: Color): void;
+    static _makeAltAzGridText(): void;
+    static _altAzTextBatch: Text3dBatch | null;
+    static _milkyWayImage: Texture;
+  }
+
+  export class Text3dBatch {
+    constructor(height: number);
+  }
+
+  export class Texture {
+    static fromUrl(url: string): Texture;
+  }
+}


### PR DESCRIPTION
This PR updates the engine to use the new GAIA Milky Way image for this interactive.