### PR TITLE
Fix some issues with switching modes

### DIFF
--- a/src/radiostars.vue
+++ b/src/radiostars.vue
@@ -704,6 +704,7 @@ export default defineComponent({
       resizeObserver: null as ResizeObserver | null,
       //background2DImageset: "Deep Star Maps 2020",
       fgName: "PLANCK R2 HFI color composition 353-545-857 GHz",
+      fg2DOpacity: 0,
       position3D: this.initialCameraParams as Omit<GotoRADecZoomParams,'instant'>,
       position2D: initial2DPosition as Omit<GotoRADecZoomParams,'instant'>,
       initial2DPosition,
@@ -1106,7 +1107,7 @@ export default defineComponent({
 
     set2DMode() {
       this.setBackgroundImageByName(this.bgName);
-      this.foregroundOpacity = this.hasBeen2D ? 70 : 0;
+      this.foregroundOpacity = this.fg2DOpacity;
       this.setForegroundImageByName(this.fgName); //AAA add function to remeber selected foreground imageset
       this.applySetting(["showSolarSystem", false]);
 
@@ -1520,12 +1521,15 @@ export default defineComponent({
     },
 
     fgName(name: string) {
-      
       if (this.modeReactive == "2D") {
         this.setForegroundImageByName(name);
-        return;
       }
-      
+    },
+
+    foregroundOpacity(opacity: number) {
+      if (this.modeReactive == "2D") {
+        this.fg2DOpacity = opacity;
+      }
     },
     
     modeReactive(newVal, oldVal) {


### PR DESCRIPTION
This PR cleans/up fixes some issues primarily related to switching between 2D and 3D modes:
* We now tween only the first time that the user goes into 2D mode (whether that's the starting mode or not)
* Clean up some redundant Promises to load the background WTML and consolidate their `then` blocks
* Remember the user's previous opacity from the 2D mode when switching back
* We don't have a splash screen, so set `showSplashScreen` to be false to start, so that we aren't repeatedly running the interval method to check on it. The machinery to do splash screen stuff is left in place in case we want to add one